### PR TITLE
README: add related functionality in sf and rgdal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,9 @@ Authors@R: c(
            role = "cph"))
 Description: The aim of this R package is to provide helper tools in 
     creating or handling GeoPackage files, in order to complement
-    other R spatial packages or GDAL.
+    other R spatial packages or GDAL. The package has no dependencies 
+    on other spatial packages and is not tied to any particular package 
+    by design.
 License: GPL (>= 3)
 Depends: 
     R (>= 3.1.0)

--- a/R/timestamp.R
+++ b/R/timestamp.R
@@ -32,7 +32,10 @@
 #' Previous value of environment variable \code{OGR_CURRENT_DATE} is returned
 #' invisibly.
 #'
-#' @family functions to control the GeoPackage timestamp(s)
+#' @seealso
+#' Other functions to control the GeoPackage timestamp(s):
+#' \code{\link{amend_timestamp}},
+#' \code{\link[sf:st_write]{sf::st_write}}
 #'
 #' @examples
 #' library(sf)
@@ -177,7 +180,10 @@ unset_timestamp <- function() Sys.unsetenv("OGR_CURRENT_DATE")
 #' @return
 #' \code{NULL} is returned invisibly.
 #'
-#' @family functions to control the GeoPackage timestamp(s)
+#' @seealso
+#' Other functions to control the GeoPackage timestamp(s):
+#' \code{\link{preset_timestamp}},
+#' \code{\link[sf:st_write]{sf::st_write}}
 #'
 #' @examples
 #' library(sf)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ So when using `sf` you're advised to pass the timestamp as follows:
   st_write(nc, 'nc.gpkg', config_options = c(OGR_CURRENT_DATE = timestamp))
   ```
   
-  Note that `OGR_CURRENT_DATE` will be unset again after each write operation.
+  Note that this does not affect the value of the environment variable `OGR_CURRENT_DATE`: `config_options = c(OGR_CURRENT_DATE = timestamp)` directly sets the GDAL `OGR_CURRENT_DATE` _configuration option_ which, if unset, inherits from the `OGR_CURRENT_DATE` environment variable.
+Also, note that `st_write()` ends by unsetting the configuration option, so set it in each `st_write()` statement as needed.
   
   In this case please take care to format the timestamp as required by the GeoPackage standard; cf. example above and [Requirement 15](https://www.geopackage.org/spec120/#r15) in version 1.2.
   

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ So when using `sf` you're advised to pass the timestamp as follows:
   Note that this does not affect the value of the environment variable `OGR_CURRENT_DATE`: `config_options = c(OGR_CURRENT_DATE = timestamp)` directly sets the GDAL `OGR_CURRENT_DATE` _configuration option_ which, if unset, inherits from the `OGR_CURRENT_DATE` environment variable.
 Also, note that `st_write()` ends by unsetting the configuration option, so set it in each `st_write()` statement as needed.
   
-  In this case please take care to format the timestamp as required by the GeoPackage standard; cf. example above and [Requirement 15](https://www.geopackage.org/spec120/#r15) in version 1.2.
+  In this case please take care to format the timestamp exactly as required by the GeoPackage standard; cf. example above and [Requirement 15](https://www.geopackage.org/spec120/#r15) in version 1.2.
   
 - for packages relying on `rgdal` it should be possible to set `OGR_CURRENT_DATE` by using `rgdal::setCPLConfigOption()` before doing the write operation.
-Again, take care to format the timestamp as required by the GeoPackage standard.
+Again, take care to format the timestamp exactly as required by the GeoPackage standard.
 
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ See the functions' documentation and examples to get a better understanding.
 remotes::install_github("florisvdh/rgeopackage")
 ```
 
+### Untied to other packages
+
+`rgeopackage` has no dependencies on other spatial packages and is not tied to any particular package by design.
+
 ### Related functionality in core spatial R packages
 
 - `sf::st_write()` is [now able to](https://github.com/r-spatial/sf/issues/1618#issuecomment-811231056) set GDAL configuration options through its `config_options` argument.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ remotes::install_github("florisvdh/rgeopackage")
 ### Related functionality in core spatial R packages
 
 - `sf::st_write()` is [now able to](https://github.com/r-spatial/sf/issues/1618#issuecomment-811231056) set GDAL configuration options through its `config_options` argument.
-So when using `sf` you're advised to pass the timestamp as follows:
+So when using `sf` you can pass the timestamp on a per-write basis:
 
   ```r
   library(sf)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Also, note that `st_write()` ends by unsetting the configuration option, so set 
   
   In this case please take care to format the timestamp exactly as required by the GeoPackage standard; cf. example above and [Requirement 15](https://www.geopackage.org/spec120/#r15) in version 1.2.
   
-- for packages relying on `rgdal` it should be possible to set `OGR_CURRENT_DATE` by using `rgdal::setCPLConfigOption()` before doing the write operation.
+- for packages relying on `rgdal` - like `sp` - it should be possible to set `OGR_CURRENT_DATE` by using `rgdal::setCPLConfigOption()` before doing the write operation.
 Again, take care to format the timestamp exactly as required by the GeoPackage standard.
 
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See the functions' documentation and examples to get a better understanding.
 remotes::install_github("florisvdh/rgeopackage")
 ```
 
-### Functionality offered by core spatial R packages
+### Related functionality in core spatial R packages
 
 - `sf::st_write()` is [now able to](https://github.com/r-spatial/sf/issues/1618#issuecomment-811231056) set GDAL configuration options through its `config_options` argument.
 So when using `sf` you're advised to pass the timestamp as follows:

--- a/README.md
+++ b/README.md
@@ -20,3 +20,26 @@ See the functions' documentation and examples to get a better understanding.
 remotes::install_github("florisvdh/rgeopackage")
 ```
 
+### Functionality offered by core spatial R packages
+
+- `sf::st_write()` is [now able to](https://github.com/r-spatial/sf/issues/1618#issuecomment-811231056) set GDAL configuration options through its `config_options` argument.
+So when using `sf` you're advised to pass the timestamp as follows:
+
+  ```r
+  library(sf)
+  nc <- st_read(system.file('shape/nc.shp', package = 'sf'), quiet = TRUE)
+  fixed_time <- as.POSIXct("2020-12-25 12:00:00", tz = "CET")
+  # or using a Date object:
+  # fixed_time <- as.Date("2020-12-25")
+  timestamp <- format(fixed_time, format = "%Y-%m-%dT%H:%M:%S.000Z", tz = "UTC")
+  st_write(nc, 'nc.gpkg', config_options = c(OGR_CURRENT_DATE = timestamp))
+  ```
+  
+  Note that `OGR_CURRENT_DATE` will be unset again after each write operation.
+  
+  In this case please take care to format the timestamp as required by the GeoPackage standard; cf. example above and [Requirement 15](https://www.geopackage.org/spec120/#r15) in version 1.2.
+  
+- for packages relying on `rgdal` it should be possible to set `OGR_CURRENT_DATE` by using `rgdal::setCPLConfigOption()` before doing the write operation.
+Again, take care to format the timestamp as required by the GeoPackage standard.
+
+

--- a/man/amend_timestamp.Rd
+++ b/man/amend_timestamp.Rd
@@ -117,10 +117,10 @@ all.equal(md5_stars1, md5_stars2)
 
 }
 \seealso{
-Other functions to control the GeoPackage timestamp(s): 
-\code{\link{preset_timestamp}()}
+Other functions to control the GeoPackage timestamp(s):
+\code{\link{preset_timestamp}},
+\code{\link[sf:st_write]{sf::st_write}}
 }
 \author{
 Floris Vanderhaeghe, \url{https://github.com/florisvdh}
 }
-\concept{functions to control the GeoPackage timestamp(s)}

--- a/man/preset_timestamp.Rd
+++ b/man/preset_timestamp.Rd
@@ -114,10 +114,10 @@ all.equal(md5_stars1, md5_stars2)
 
 }
 \seealso{
-Other functions to control the GeoPackage timestamp(s): 
-\code{\link{amend_timestamp}()}
+Other functions to control the GeoPackage timestamp(s):
+\code{\link{amend_timestamp}},
+\code{\link[sf:st_write]{sf::st_write}}
 }
 \author{
 Floris Vanderhaeghe, \url{https://github.com/florisvdh}
 }
-\concept{functions to control the GeoPackage timestamp(s)}


### PR DESCRIPTION
Added these references especially because `sf::st_write()` [obtained](https://github.com/r-spatial/sf/issues/1618#issuecomment-811231056) the ability to pass GDAL configuration options. Its new argument `config_options` can be used to pass a fixed timestamp to GDAL (implemented on a per-write basis). The timestamp must be correctly formatted by the user in order to comply with the GeoPackage standard. See new section added to README, with example code.